### PR TITLE
Add project skeleton documentation and placeholders

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,4 +35,13 @@ target_link_libraries(netstrum_dll ${Boost_LIBRARIES})
 
 install(TARGETS netstrum_dll DESTINATION bin)
 
+# Add optional subprojects when build scripts are present
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/dll/CMakeLists.txt")
+    add_subdirectory(dll)
+endif()
+
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/gui/CMakeLists.txt")
+    add_subdirectory(gui)
+endif()
+
 # add_subdirectory(tests)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,36 @@
+# Netstrum
+
+Netstrum is a modular framework for experimenting with network packet instrumentation.
+The project is split into multiple subprojects that work together to provide a
+flexible platform for logging, observing and manipulating network traffic.
+
+## Architecture
+
+The repository is organized into several components:
+
+- **Core library** – shared logic that powers packet observation and command
+  processing.  It is built as the `netstrum_dll` library.
+- **dll/** – planned native extension containing packet instrumentation hooks.
+- **gui/** – planned graphical interface for interacting with the instrumentation
+  layer.
+
+## Build requirements
+
+Netstrum uses a modern C++ toolchain and relies on the following tools:
+
+- [CMake](https://cmake.org/) for generating project files.
+- [vcpkg](https://github.com/microsoft/vcpkg) for dependency management.
+- [Visual Studio](https://visualstudio.microsoft.com/) on Windows for building and
+  debugging.
+
+## Usage overview
+
+1. Install the required tools and ensure `vcpkg` is integrated with CMake.
+2. Generate build files, for example:
+   ```bash
+   cmake -S . -B build -DCMAKE_TOOLCHAIN_FILE="<path to vcpkg.cmake>"
+   ```
+3. Build the desired targets using your chosen build system (e.g. `cmake --build build`).
+
+The `dll` and `gui` directories currently contain placeholders and will gain
+CMake build scripts and functionality in future revisions.

--- a/dll/README.md
+++ b/dll/README.md
@@ -1,0 +1,4 @@
+# DLL Subproject
+
+Placeholder for the packet instrumentation dynamic library.
+Future work will include CMake build scripts and implementation files.

--- a/gui/README.md
+++ b/gui/README.md
@@ -1,0 +1,4 @@
+# GUI Subproject
+
+Placeholder for the graphical interface used to interact with Netstrum.
+Future work will include CMake build scripts and implementation files.


### PR DESCRIPTION
## Summary
- Document Netstrum's purpose, architecture, build requirements, and usage in a new root README.
- Introduce placeholder `dll` and `gui` subproject directories, each with a brief README.
- Update root CMakeLists to conditionally include `dll` and `gui` when their CMake build scripts exist.

## Testing
- `cmake -S . -B build` *(fails: Could NOT find Boost)*

------
https://chatgpt.com/codex/tasks/task_e_6898ab914c888320851832a8604b7512