### PR TITLE
Add vcpkg configuration and dependency docs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,11 @@ cmake_minimum_required(VERSION 3.10)
 
 project(netstrum)
 
+find_package(Boost COMPONENTS log system REQUIRED)
+find_package(detours CONFIG REQUIRED)
+find_package(fmt CONFIG REQUIRED)
+find_package(asio CONFIG REQUIRED)
+
 include_directories(
     ${Boost_INCLUDE_DIR}
     ${CMAKE_CURRENT_SOURCE_DIR}/src/core/logging/
@@ -12,8 +17,6 @@ include_directories(
     ${CMAKE_CURRENT_SOURCE_DIR}/src/core/hooking/
     ${CMAKE_CURRENT_SOURCE_DIR}/src/dll/
 )
-
-find_package(Boost COMPONENTS log system REQUIRED)
 
 add_library(netstrum_dll SHARED
     src/core/event/Event.cpp
@@ -28,10 +31,13 @@ add_library(netstrum_dll SHARED
     src/dll/PacketInstrumentationDLL.cpp
 )
 
-# find_package(Detours REQUIRED)
-# target_link_libraries(netstrum_dll Detours)
-
-target_link_libraries(netstrum_dll ${Boost_LIBRARIES})
+target_link_libraries(netstrum_dll
+    PRIVATE
+        ${Boost_LIBRARIES}
+        detours
+        fmt::fmt
+        asio::asio
+)
 
 install(TARGETS netstrum_dll DESTINATION bin)
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,28 @@
+# Netstrum
+
+This project uses [vcpkg](https://github.com/microsoft/vcpkg) for dependency management.
+
+## Installing vcpkg
+
+```bash
+# Clone vcpkg
+git clone https://github.com/microsoft/vcpkg.git
+cd vcpkg
+
+# Bootstrap vcpkg
+./bootstrap-vcpkg.sh  # or .\bootstrap-vcpkg.bat on Windows
+
+# Install dependencies for this project
+./vcpkg install --triplet x64-windows # adjust triplet as needed
+```
+
+## CMake configuration
+
+When configuring the project with CMake, set the `CMAKE_TOOLCHAIN_FILE` to use vcpkg's build system file:
+
+```bash
+cmake -S . -B build -DCMAKE_TOOLCHAIN_FILE=/path/to/vcpkg/scripts/buildsystems/vcpkg.cmake
+cmake --build build
+```
+
+Replace `/path/to/vcpkg` with the path where vcpkg was cloned.

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,11 @@
+{
+  "name": "netstrum",
+  "version": "0.1.0",
+  "dependencies": [
+    "detours",
+    "fmt",
+    "asio",
+    "boost-log",
+    "boost-system"
+  ]
+}


### PR DESCRIPTION
## Summary
- Declare detours, fmt, asio, and Boost components in a new `vcpkg.json`
- Document vcpkg installation and `CMAKE_TOOLCHAIN_FILE` usage in `README.md`
- Update `CMakeLists.txt` to find and link detours, fmt, and asio

## Testing
- `cmake -S . -B build` *(fails: Could NOT find Boost (missing: Boost_INCLUDE_DIR log system))*

------
https://chatgpt.com/codex/tasks/task_e_6898c14857488320b26451b7c734f516