### PR TITLE
Add WPF GUI skeleton with TCP listener

### DIFF
--- a/gui/App.xaml
+++ b/gui/App.xaml
@@ -1,0 +1,7 @@
+<Application x:Class="netstrum_gui.App"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             StartupUri="MainWindow.xaml">
+    <Application.Resources>
+    </Application.Resources>
+</Application>

--- a/gui/App.xaml.cs
+++ b/gui/App.xaml.cs
@@ -1,0 +1,8 @@
+using System.Windows;
+
+namespace netstrum_gui
+{
+    public partial class App : Application
+    {
+    }
+}

--- a/gui/MainWindow.xaml
+++ b/gui/MainWindow.xaml
@@ -1,0 +1,35 @@
+<Window x:Class="netstrum_gui.MainWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Netstrum GUI" Height="450" Width="800">
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
+        <StackPanel Orientation="Horizontal" Margin="5">
+            <Button Content="Select Process" Click="SelectProcess_Click" Margin="0,0,5,0"/>
+            <Button Content="Attach" Click="Attach_Click" Margin="0,0,5,0"/>
+            <Button Content="Detach" Click="Detach_Click" Margin="0,0,5,0"/>
+            <Button Content="Capture" Click="Capture_Click" Margin="0,0,5,0"/>
+            <Button Content="Stop" Click="Stop_Click"/>
+        </StackPanel>
+        <Grid Grid.Row="1">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="2*"/>
+                <ColumnDefinition Width="*"/>
+            </Grid.ColumnDefinitions>
+            <DataGrid x:Name="PacketGrid" ItemsSource="{Binding Packets}" SelectedItem="{Binding SelectedPacket, Mode=TwoWay}" AutoGenerateColumns="False" Grid.Column="0" Margin="5">
+                <DataGrid.Columns>
+                    <DataGridTextColumn Header="Time" Binding="{Binding Timestamp}" Width="*"/>
+                    <DataGridTextColumn Header="Data" Binding="{Binding Data}" Width="2*"/>
+                </DataGrid.Columns>
+            </DataGrid>
+            <StackPanel Grid.Column="1" Margin="5">
+                <TextBlock Text="Packet Details" FontWeight="Bold" Margin="0,0,0,5"/>
+                <TextBox Text="{Binding SelectedPacket.Data, Mode=TwoWay}" Height="100" TextWrapping="Wrap"/>
+                <Button Content="Save" Click="SavePacket_Click" Margin="0,5,0,0" Width="75"/>
+            </StackPanel>
+        </Grid>
+    </Grid>
+</Window>

--- a/gui/MainWindow.xaml.cs
+++ b/gui/MainWindow.xaml.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Windows;
+
+namespace netstrum_gui
+{
+    public partial class MainWindow : Window, INotifyPropertyChanged
+    {
+        public ObservableCollection<Packet> Packets { get; } = new();
+        private Packet? _selectedPacket;
+        private int? _selectedProcessId;
+        private readonly TcpListenerService _listener = new(9000);
+
+        public Packet? SelectedPacket
+        {
+            get => _selectedPacket;
+            set { _selectedPacket = value; OnPropertyChanged(nameof(SelectedPacket)); }
+        }
+
+        public MainWindow()
+        {
+            InitializeComponent();
+            DataContext = this;
+            _listener.PacketReceived += OnPacketReceived;
+        }
+
+        private void OnPacketReceived(string data)
+        {
+            Dispatcher.Invoke(() => Packets.Add(new Packet { Data = data, Timestamp = DateTime.Now }));
+        }
+
+        private void SelectProcess_Click(object sender, RoutedEventArgs e)
+        {
+            var picker = new ProcessPickerWindow();
+            if (picker.ShowDialog() == true && picker.SelectedProcess != null)
+            {
+                _selectedProcessId = picker.SelectedProcess.Id;
+            }
+        }
+
+        private void Attach_Click(object sender, RoutedEventArgs e)
+        {
+            if (_selectedProcessId.HasValue)
+            {
+                MessageBox.Show($"Attached to process {_selectedProcessId}");
+            }
+        }
+
+        private void Detach_Click(object sender, RoutedEventArgs e)
+        {
+            MessageBox.Show("Detached");
+        }
+
+        private void Capture_Click(object sender, RoutedEventArgs e)
+        {
+            _ = _listener.StartAsync();
+        }
+
+        private void Stop_Click(object sender, RoutedEventArgs e)
+        {
+            _listener.Stop();
+        }
+
+        private void SavePacket_Click(object sender, RoutedEventArgs e)
+        {
+            // Binding updates data automatically
+        }
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+        private void OnPropertyChanged(string propertyName) => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+}

--- a/gui/Packet.cs
+++ b/gui/Packet.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace netstrum_gui
+{
+    public class Packet
+    {
+        public DateTime Timestamp { get; set; } = DateTime.Now;
+        public string Data { get; set; } = string.Empty;
+    }
+}

--- a/gui/ProcessPickerWindow.xaml
+++ b/gui/ProcessPickerWindow.xaml
@@ -1,0 +1,13 @@
+<Window x:Class="netstrum_gui.ProcessPickerWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Select Process" Height="400" Width="300">
+    <Grid Margin="5">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+        <ListBox x:Name="ProcessList" DisplayMemberPath="ProcessName"/>
+        <Button Grid.Row="1" Content="OK" Width="75" Margin="0,5,0,0" HorizontalAlignment="Right" Click="Ok_Click"/>
+    </Grid>
+</Window>

--- a/gui/ProcessPickerWindow.xaml.cs
+++ b/gui/ProcessPickerWindow.xaml.cs
@@ -1,0 +1,23 @@
+using System.Diagnostics;
+using System.Linq;
+using System.Windows;
+
+namespace netstrum_gui
+{
+    public partial class ProcessPickerWindow : Window
+    {
+        public Process? SelectedProcess { get; private set; }
+
+        public ProcessPickerWindow()
+        {
+            InitializeComponent();
+            ProcessList.ItemsSource = Process.GetProcesses().OrderBy(p => p.ProcessName);
+        }
+
+        private void Ok_Click(object sender, RoutedEventArgs e)
+        {
+            SelectedProcess = ProcessList.SelectedItem as Process;
+            DialogResult = SelectedProcess != null;
+        }
+    }
+}

--- a/gui/README.md
+++ b/gui/README.md
@@ -1,4 +1,17 @@
-# GUI Subproject
+# Netstrum GUI
 
-Placeholder for the graphical interface used to interact with Netstrum.
-Future work will include CMake build scripts and implementation files.
+This directory contains a simple WPF application used to interact with Netstrum.
+
+## Building
+
+1. Ensure the .NET SDK 6.0 or later is installed.
+2. Restore NuGet packages:
+   ```sh
+   dotnet restore
+   ```
+3. Build the project:
+   ```sh
+   dotnet build
+   ```
+
+When building on non-Windows platforms, append `-p:EnableWindowsTargeting=true` to the commands.

--- a/gui/TcpListenerService.cs
+++ b/gui/TcpListenerService.cs
@@ -1,0 +1,58 @@
+using System;
+using System.IO;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace netstrum_gui
+{
+    public class TcpListenerService
+    {
+        private readonly TcpListener _listener;
+        private CancellationTokenSource? _cts;
+        public event Action<string>? PacketReceived;
+
+        public TcpListenerService(int port)
+        {
+            _listener = new TcpListener(IPAddress.Loopback, port);
+        }
+
+        public async Task StartAsync()
+        {
+            _cts = new CancellationTokenSource();
+            _listener.Start();
+            try
+            {
+                while (!_cts.Token.IsCancellationRequested)
+                {
+                    var client = await _listener.AcceptTcpClientAsync(_cts.Token);
+                    _ = HandleClientAsync(client, _cts.Token);
+                }
+            }
+            catch (OperationCanceledException)
+            {
+            }
+        }
+
+        private async Task HandleClientAsync(TcpClient client, CancellationToken token)
+        {
+            using var reader = new StreamReader(client.GetStream(), Encoding.UTF8);
+            while (!token.IsCancellationRequested && !reader.EndOfStream)
+            {
+                var line = await reader.ReadLineAsync();
+                if (line != null)
+                {
+                    PacketReceived?.Invoke(line);
+                }
+            }
+        }
+
+        public void Stop()
+        {
+            _cts?.Cancel();
+            _listener.Stop();
+        }
+    }
+}

--- a/gui/netstrum_gui.csproj
+++ b/gui/netstrum_gui.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net6.0-windows</TargetFramework>
+    <UseWPF>true</UseWPF>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
## Summary
- Initialize `netstrum_gui` WPF project targeting .NET 6
- Build out `MainWindow` with process selection, attach/detach and capture controls
- Add `TcpListener` service and packet model for GUI
- Document restore and build steps

## Testing
- `dotnet restore -p:EnableWindowsTargeting=true`
- `dotnet build -p:EnableWindowsTargeting=true` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_6898cf57db008320859277936230896b